### PR TITLE
[breaking] fix typo: methos -> method

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ fn main() {
 fn expected() -> BrCode {
     BrCode {
         payload_version: 1,
-        initiation_methos: None,
+        initiation_method: None,
         merchant_category_code: 0000u32,
         merchant_name: "NOME DO RECEBEDOR".to_string(),
         merchant_city: "BRASILIA".to_string(),
@@ -214,7 +214,7 @@ fn main() {
 fn brcode_value() -> BrCode {
     BrCode {
         payload_version: 1,
-        initiation_methos: None,
+        initiation_method: None,
         merchant_account_information: Some(String::from("12345678901234")),
         merchant_category_code: 0000u32,
         merchant_name: "NOME DO RECEBEDOR".to_string(),
@@ -323,7 +323,7 @@ time:   [3.0738 us 3.0825 us 3.0938 us]
 
 (brcode->edn code)
 
-; {:payload-version 1, :initiation-methos nil, :merchant-information [{:id 26, :info [{:id 0, :info "BR.GOV.BCB.PIX"}, {:id 1, :info "123e4567-e12b-12d1-a456-426655440000"}]}, {:id 27, :info [{:id 0, :info "BR.COM.OUTRO"}, {:id 1, :info "0123456789"}]}], :merchant-category-code 0, :merchant-name "NOME DO RECEBEDOR", :merchant-city "BRASILIA", :postal-code "70074900", :currency "986", :amount 123.45, :country-code "BR", :field-template [{:reference-label "RP12345678-2019"}], :crc1610 "AD38", :templates [{:id 80, :info [{:id 0, :info "BR.COM.OUTRO"}, {:id 1, :info "0123.ABCD.3456.WXYZ"}]}]}
+; {:payload-version 1, :initiation-method nil, :merchant-information [{:id 26, :info [{:id 0, :info "BR.GOV.BCB.PIX"}, {:id 1, :info "123e4567-e12b-12d1-a456-426655440000"}]}, {:id 27, :info [{:id 0, :info "BR.COM.OUTRO"}, {:id 1, :info "0123456789"}]}], :merchant-category-code 0, :merchant-name "NOME DO RECEBEDOR", :merchant-city "BRASILIA", :postal-code "70074900", :currency "986", :amount 123.45, :country-code "BR", :field-template [{:reference-label "RP12345678-2019"}], :crc1610 "AD38", :templates [{:id 80, :info [{:id 0, :info "BR.COM.OUTRO"}, {:id 1, :info "0123.ABCD.3456.WXYZ"}]}]}
 ```
 
 Input:
@@ -333,7 +333,7 @@ Input:
 
 Expected Edn:
 ```clojure
-{:payload-version 1,:initiation-methos nil, :merchant-information [
+{:payload-version 1,:initiation-method nil, :merchant-information [
   {:id 26, :info [{ :id 0, :info "BR.GOV.BCB.PIX",}, {:id 1, :info "123e4567-e12b-12d1-a456-426655440000",}]},
   {:id 27, :info [{ :id 0, :info "BR.COM.OUTRO",}, {:id 1, :info "0123456789",}]}
  ],:merchant-category-code 0, :merchant-name "NOME DO RECEBEDOR", :merchant-city "BRASILIA", 
@@ -349,7 +349,7 @@ Expected Edn:
 (ns example.core
   (:require [clj-brcode.core :refer :all]))
 
-(def edn {:payload-version 1, :initiation-methos nil, :merchant-information [{:id 26, :info [{:id 0, :info "BR.GOV.BCB.PIX"}, {:id 1, :info "123e4567-e12b-12d1-a456-426655440000"}]}, {:id 27, :info [{:id 0, :info "BR.COM.OUTRO"}, {:id 1, :info "0123456789"}]}], :merchant-category-code 0, :merchant-name "NOME DO RECEBEDOR", :merchant-city "BRASILIA", :postal-code "70074900", :currency "986", :amount 123.45, :country-code "BR", :field-template [{:reference-label "RP12345678-2019"}], :crc1610 "AD38", :templates [{:id 80, :info [{:id 0, :info "BR.COM.OUTRO"}, {:id 1, :info "0123.ABCD.3456.WXYZ"}]}]})
+(def edn {:payload-version 1, :initiation-method nil, :merchant-information [{:id 26, :info [{:id 0, :info "BR.GOV.BCB.PIX"}, {:id 1, :info "123e4567-e12b-12d1-a456-426655440000"}]}, {:id 27, :info [{:id 0, :info "BR.COM.OUTRO"}, {:id 1, :info "0123456789"}]}], :merchant-category-code 0, :merchant-name "NOME DO RECEBEDOR", :merchant-city "BRASILIA", :postal-code "70074900", :currency "986", :amount 123.45, :country-code "BR", :field-template [{:reference-label "RP12345678-2019"}], :crc1610 "AD38", :templates [{:id 80, :info [{:id 0, :info "BR.COM.OUTRO"}, {:id 1, :info "0123.ABCD.3456.WXYZ"}]}]})
 
 (brcode->edn edn)
 
@@ -398,7 +398,7 @@ const brcode = require('node-brecode');
 const code = "00020104141234567890123426580014BR.GOV.BCB.PIX0136123e4567-e12b-12d1-a456-42665544000027300012BR.COM.OUTRO011001234567895204000053039865406123.455802BR5917NOME DO RECEBEDOR6008BRASILIA61087007490062190515RP12345678-201980390012BR.COM.OUTRO01190123.ABCD.3456.WXYZ6304AD38";
 
 console.log(brcode.parse(code));
-// {"payload_version":1,"initiation_methos":null, 
+// {"payload_version":1,"initiation_method":null, 
 // "merchant_information":[
 //   {"id":26,"info":[{"id":0,"info":"BR.GOV.BCB.PIX"},{"id":1,"info":"123e4567-e12b-12d1-a456-426655440000"}]},
 //   {"id":27,"info":[{"id":0,"info":"BR.COM.OUTRO"},{"id":1,"info":"0123456789"}]}
@@ -417,7 +417,7 @@ Input:
 
 Expected Json:
 ```json
-{"payload_version":1,"initiation_methos":null, 
+{"payload_version":1,"initiation_method":null, 
 "merchant_information":[
   {"id":26,"info":[{"id":0,"info":"BR.GOV.BCB.PIX"},{"id":1,"info":"123e4567-e12b-12d1-a456-426655440000"}]},
   {"id":27,"info":[{"id":0,"info":"BR.COM.OUTRO"},{"id":1,"info":"0123456789"}]}
@@ -432,7 +432,7 @@ Expected Json:
 **Json as BR Code** call function `emit`. Example:
 ```js
 const brcode = require('node-brcode');
-const json = {"payload_version":1,"initiation_methos":null, 
+const json = {"payload_version":1,"initiation_method":null, 
 "merchant_information":[
   {"id":26,"info":[{"id":0,"info":"BR.GOV.BCB.PIX"},{"id":1,"info":"123e4567-e12b-12d1-a456-426655440000"}]},
   {"id":27,"info":[{"id":0,"info":"BR.COM.OUTRO"},{"id":1,"info":"0123456789"}]}

--- a/clj-brcode/README.md
+++ b/clj-brcode/README.md
@@ -55,7 +55,7 @@ Clojure wrapper of `brcode` to parse and emit [PIX BR Code](https://www.bcb.gov.
 ```clojure
 (def brcode "00020104141234567890123426580014BR.GOV.BCB.PIX0136123e4567-e12b-12d1-a456-42665544000027300012BR.COM.OUTRO011001234567895204000053039865406123.455802BR5917NOME DO RECEBEDOR6008BRASILIA61087007490062190515RP12345678-201980390012BR.COM.OUTRO01190123.ABCD.3456.WXYZ6304AD38")
 
-(def edn {:payload-version 1, :initiation-methos nil, :merchant-information [{:id 26, :info [{:id 0, :info "BR.GOV.BCB.PIX"}, {:id 1, :info "123e4567-e12b-12d1-a456-426655440000"}]}, {:id 27, :info [{:id 0, :info "BR.COM.OUTRO"}, {:id 1, :info "0123456789"}]}], :merchant-category-code 0, :merchant-name "NOME DO RECEBEDOR", :merchant-city "BRASILIA", :postal-code "70074900", :currency "986", :amount 123.45, :country-code "BR", :field-template [{:reference-label "RP12345678-2019"}], :crc1610 "AD38", :templates [{:id 80, :info [{:id 0, :info "BR.COM.OUTRO"}, {:id 1, :info "0123.ABCD.3456.WXYZ"}]}]})
+(def edn {:payload-version 1, :initiation-method nil, :merchant-information [{:id 26, :info [{:id 0, :info "BR.GOV.BCB.PIX"}, {:id 1, :info "123e4567-e12b-12d1-a456-426655440000"}]}, {:id 27, :info [{:id 0, :info "BR.COM.OUTRO"}, {:id 1, :info "0123456789"}]}], :merchant-category-code 0, :merchant-name "NOME DO RECEBEDOR", :merchant-city "BRASILIA", :postal-code "70074900", :currency "986", :amount 123.45, :country-code "BR", :field-template [{:reference-label "RP12345678-2019"}], :crc1610 "AD38", :templates [{:id 80, :info [{:id 0, :info "BR.COM.OUTRO"}, {:id 1, :info "0123.ABCD.3456.WXYZ"}]}]})
 
 (= (brcode->edn brcode) edn)
 ```
@@ -63,7 +63,7 @@ Clojure wrapper of `brcode` to parse and emit [PIX BR Code](https://www.bcb.gov.
 **edn->brcode**
 ```clojure
 (def code "00020104141234567890123426580014BR.GOV.BCB.PIX0136123e4567-e12b-12d1-a456-42665544000027300012BR.COM.OUTRO011001234567895204000053039865406123.455802BR5917NOME DO RECEBEDOR6008BRASILIA61087007490062190515RP12345678-201980390012BR.COM.OUTRO01190123.ABCD.3456.WXYZ6304AD38")
-(def edn {:payload-version 1, :initiation-methos nil, :merchant-account-information "12345678901234" :merchant-information [{:id 26, :info [{:id 0, :info "BR.GOV.BCB.PIX"}, {:id 1, :info "123e4567-e12b-12d1-a456-426655440000"}]}, {:id 27, :info [{:id 0, :info "BR.COM.OUTRO"}, {:id 1, :info "0123456789"}]}], :merchant-category-code 0, :merchant-name "NOME DO RECEBEDOR", :merchant-city "BRASILIA", :postal-code "70074900", :currency "986", :amount 123.45, :country-code "BR", :field-template [{:reference-label "RP12345678-2019"}], :crc1610 "AD38", :templates [{:id 80, :info [{:id 0, :info "BR.COM.OUTRO"}, {:id 1, :info "0123.ABCD.3456.WXYZ"}]}]})
+(def edn {:payload-version 1, :initiation-method nil, :merchant-account-information "12345678901234" :merchant-information [{:id 26, :info [{:id 0, :info "BR.GOV.BCB.PIX"}, {:id 1, :info "123e4567-e12b-12d1-a456-426655440000"}]}, {:id 27, :info [{:id 0, :info "BR.COM.OUTRO"}, {:id 1, :info "0123456789"}]}], :merchant-category-code 0, :merchant-name "NOME DO RECEBEDOR", :merchant-city "BRASILIA", :postal-code "70074900", :currency "986", :amount 123.45, :country-code "BR", :field-template [{:reference-label "RP12345678-2019"}], :crc1610 "AD38", :templates [{:id 80, :info [{:id 0, :info "BR.COM.OUTRO"}, {:id 1, :info "0123.ABCD.3456.WXYZ"}]}]})
 
 (= (edn->brcode edn) code)
 

--- a/clj-brcode/test/clj_brcode/core_test.clj
+++ b/clj-brcode/test/clj_brcode/core_test.clj
@@ -3,7 +3,7 @@
             [clj-brcode.core :refer :all]))
 
 (def code "00020104141234567890123426580014BR.GOV.BCB.PIX0136123e4567-e12b-12d1-a456-42665544000027300012BR.COM.OUTRO011001234567895204000053039865406123.455802BR5917NOME DO RECEBEDOR6008BRASILIA61087007490062190515RP12345678-201980390012BR.COM.OUTRO01190123.ABCD.3456.WXYZ6304AD38")
-(def edn {:payload-version 1, :initiation-methos nil, :merchant-account-information "12345678901234" :merchant-information [{:id 26, :info [{:id 0, :info "BR.GOV.BCB.PIX"}, {:id 1, :info "123e4567-e12b-12d1-a456-426655440000"}]}, {:id 27, :info [{:id 0, :info "BR.COM.OUTRO"}, {:id 1, :info "0123456789"}]}], :merchant-category-code 0, :merchant-name "NOME DO RECEBEDOR", :merchant-city "BRASILIA", :postal-code "70074900", :currency "986", :amount 123.45, :country-code "BR", :field-template [{:reference-label "RP12345678-2019"}], :crc1610 "AD38", :templates [{:id 80, :info [{:id 0, :info "BR.COM.OUTRO"}, {:id 1, :info "0123.ABCD.3456.WXYZ"}]}]})
+(def edn {:payload-version 1, :initiation-method nil, :merchant-account-information "12345678901234" :merchant-information [{:id 26, :info [{:id 0, :info "BR.GOV.BCB.PIX"}, {:id 1, :info "123e4567-e12b-12d1-a456-426655440000"}]}, {:id 27, :info [{:id 0, :info "BR.COM.OUTRO"}, {:id 1, :info "0123456789"}]}], :merchant-category-code 0, :merchant-name "NOME DO RECEBEDOR", :merchant-city "BRASILIA", :postal-code "70074900", :currency "986", :amount 123.45, :country-code "BR", :field-template [{:reference-label "RP12345678-2019"}], :crc1610 "AD38", :templates [{:id 80, :info [{:id 0, :info "BR.COM.OUTRO"}, {:id 1, :info "0123.ABCD.3456.WXYZ"}]}]})
 
 (deftest brcode-test
   (testing "conform rust result to clojure"

--- a/node-brcode/README.md
+++ b/node-brcode/README.md
@@ -43,7 +43,7 @@ Output:
 ```json
 {
     "payload_version":1,
-    "initiation_methos":null,
+    "initiation_method":null,
     "merchant_information":[
         {"id":26,"info":[
             {"id":0,"info":"BR.GOV.BCB.PIX"},
@@ -77,7 +77,7 @@ Output:
 const brcode = require('node-brcode');
 const json = {
     "payload_version":1,
-    "initiation_methos":null,
+    "initiation_method":null,
     "merchant_information":[
         {"id":26,"info":[
             {"id":0,"info":"BR.GOV.BCB.PIX"},

--- a/node-brcode/index.test.js
+++ b/node-brcode/index.test.js
@@ -9,7 +9,7 @@ const code = "00020104141234567890123426580014BR.GOV.BCB.PIX0136123e4567-e12b-12
 
 const json = {
     "payload_version":1,
-    "initiation_methos":null,
+    "initiation_method":null,
     "merchant_account_information": "12345678901234",
     "merchant_information":[
         {"id":26,"info":[

--- a/src/model.rs
+++ b/src/model.rs
@@ -6,7 +6,7 @@ use serde_derive::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize}
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, SerdeDeserialize, SerdeSerialize)]
 pub struct BrCode {
     pub payload_version: u8,
-    pub initiation_methos: Option<u8>,
+    pub initiation_method: Option<u8>,
     pub merchant_account_information: Option<String>,
     pub merchant_information: Vec<MerchantInfo>,
     pub merchant_category_code: u32,
@@ -98,7 +98,7 @@ impl From<Vec<(usize, Data)>> for BrCode {
 
         BrCode {
             payload_version: hash[&0usize].to_str().parse().unwrap(),
-            initiation_methos: hash.get(&1usize).map(|e| e.to_str().parse().unwrap()),
+            initiation_method: hash.get(&1usize).map(|e| e.to_str().parse().unwrap()),
             merchant_account_information: hash.get(&4usize).map(crate::aux::Data::to_str),
             merchant_information: merchant_information,
             merchant_category_code: hash[&52usize].to_str().parse().unwrap(),
@@ -125,7 +125,7 @@ impl BrCode {
     pub fn encode(self) -> String {
         let mut encode = String::new();
         encode.push_str(&format!("0002{:02}", self.payload_version));
-        match self.initiation_methos {
+        match self.initiation_method {
             None => (),
             Some(m) => encode.push_str(&format!("0102{:02}", m)),
         }
@@ -208,7 +208,7 @@ mod test {
     fn expected() -> BrCode {
         BrCode {
             payload_version: 1,
-            initiation_methos: None,
+            initiation_method: None,
             merchant_account_information: Some(String::from("12345678901234")),
             merchant_category_code: 0000u32,
             merchant_name: "NOME DO RECEBEDOR".to_string(),
@@ -273,7 +273,7 @@ mod test {
     fn brcode_value() -> BrCode {
         BrCode {
             payload_version: 1,
-            initiation_methos: None,
+            initiation_method: None,
             merchant_account_information: Some(String::from("12345678901234")),
             merchant_category_code: 0000u32,
             merchant_name: "NOME DO RECEBEDOR".to_string(),

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -96,19 +96,19 @@ fn code() -> String {
 }
 
 fn json() -> String {
-    "{\"payload_version\":1,\"initiation_methos\":null,\"merchant_account_information\":\"12345678901234\",\"merchant_information\":[{\"id\":26,\"info\":[{\"id\":0,\"info\":\"BR.GOV.BCB.PIX\"},{\"id\":1,\"info\":\"123e4567-e12b-12d1-a456-426655440000\"}]},{\"id\":27,\"info\":[{\"id\":0,\"info\":\"BR.COM.OUTRO\"},{\"id\":1,\"info\":\"0123456789\"}]}],\"merchant_category_code\":0,\"merchant_name\":\"NOME DO RECEBEDOR\",\"merchant_city\":\"BRASILIA\",\"postal_code\":\"70074900\",\"currency\":\"986\",\"amount\":123.45,\"country_code\":\"BR\",\"field_template\":[{\"reference_label\":\"RP12345678-2019\"}],\"crc1610\":\"AD38\",\"templates\":[{\"id\":80,\"info\":[{\"id\":0,\"info\":\"BR.COM.OUTRO\"},{\"id\":1,\"info\":\"0123.ABCD.3456.WXYZ\"}]}]}"
+    "{\"payload_version\":1,\"initiation_method\":null,\"merchant_account_information\":\"12345678901234\",\"merchant_information\":[{\"id\":26,\"info\":[{\"id\":0,\"info\":\"BR.GOV.BCB.PIX\"},{\"id\":1,\"info\":\"123e4567-e12b-12d1-a456-426655440000\"}]},{\"id\":27,\"info\":[{\"id\":0,\"info\":\"BR.COM.OUTRO\"},{\"id\":1,\"info\":\"0123456789\"}]}],\"merchant_category_code\":0,\"merchant_name\":\"NOME DO RECEBEDOR\",\"merchant_city\":\"BRASILIA\",\"postal_code\":\"70074900\",\"currency\":\"986\",\"amount\":123.45,\"country_code\":\"BR\",\"field_template\":[{\"reference_label\":\"RP12345678-2019\"}],\"crc1610\":\"AD38\",\"templates\":[{\"id\":80,\"info\":[{\"id\":0,\"info\":\"BR.COM.OUTRO\"},{\"id\":1,\"info\":\"0123.ABCD.3456.WXYZ\"}]}]}"
     .to_string()
 }
 
 fn edn() -> String {
-    "{ :payload-version 1, :initiation-methos nil, :merchant-account-information \"12345678901234\", :merchant-information [{ :id 26, :info [{ :id 0, :info \"BR.GOV.BCB.PIX\", }, { :id 1, :info \"123e4567-e12b-12d1-a456-426655440000\", }], }, { :id 27, :info [{ :id 0, :info \"BR.COM.OUTRO\", }, { :id 1, :info \"0123456789\", }], }], :merchant-category-code 0, :merchant-name \"NOME DO RECEBEDOR\", :merchant-city \"BRASILIA\", :postal-code \"70074900\", :currency \"986\", :amount 123.45, :country-code \"BR\", :field-template [{ :reference-label \"RP12345678-2019\", }], :crc1610 \"AD38\", :templates [{ :id 80, :info [{ :id 0, :info \"BR.COM.OUTRO\", }, { :id 1, :info \"0123.ABCD.3456.WXYZ\", }], }], }"
+    "{ :payload-version 1, :initiation-method nil, :merchant-account-information \"12345678901234\", :merchant-information [{ :id 26, :info [{ :id 0, :info \"BR.GOV.BCB.PIX\", }, { :id 1, :info \"123e4567-e12b-12d1-a456-426655440000\", }], }, { :id 27, :info [{ :id 0, :info \"BR.COM.OUTRO\", }, { :id 1, :info \"0123456789\", }], }], :merchant-category-code 0, :merchant-name \"NOME DO RECEBEDOR\", :merchant-city \"BRASILIA\", :postal-code \"70074900\", :currency \"986\", :amount 123.45, :country-code \"BR\", :field-template [{ :reference-label \"RP12345678-2019\", }], :crc1610 \"AD38\", :templates [{ :id 80, :info [{ :id 0, :info \"BR.COM.OUTRO\", }, { :id 1, :info \"0123.ABCD.3456.WXYZ\", }], }], }"
     .to_string()
 }
 
 fn brcode_expected() -> BrCode {
     BrCode {
         payload_version: 1,
-        initiation_methos: None,
+        initiation_method: None,
         merchant_account_information: Some(String::from("12345678901234")),
         merchant_category_code: 0000u32,
         merchant_name: "NOME DO RECEBEDOR".to_string(),


### PR DESCRIPTION
Fixes a typo in BrCode model: `initiation_methos` -> `initiation_method`

**This is a breaking change**