### PR TITLE
Conform amount to ISO4217

### DIFF
--- a/src/aux.rs
+++ b/src/aux.rs
@@ -69,7 +69,24 @@ pub fn crc16_ccitt(message: &str) -> String {
 
     crc &= 0xffff;
 
-    format!("{:X}", crc)
+    format!("{:X}", crc).prepend_remaining_length(4, '0')
+}
+
+trait Field {
+    fn prepend_remaining_length(&self, length: usize, character: char) -> String;
+}
+
+impl Field for String {
+    fn prepend_remaining_length(&self, length: usize, character: char) -> String {
+        let mut string = self.to_owned();
+        let limit = length - string.len();
+
+        for _i in 0..limit {
+            string.insert(0, character);
+        }
+
+        string
+    }
 }
 
 #[cfg(test)]
@@ -153,5 +170,17 @@ mod test {
         let hash: HashBrCode = vec.into_iter().collect();
 
         assert_eq!(hash.0, expected);
+    }
+
+    #[test]
+    fn prepends_the_remaining_length() {
+        let missing_characters = "123".to_string();
+        let with_all_characters = "12345".to_string();
+
+        assert_eq!(missing_characters.prepend_remaining_length(5, '0'), "00123");
+        assert_eq!(
+            with_all_characters.prepend_remaining_length(5, '0'),
+            "12345"
+        );
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -221,7 +221,7 @@ impl BrCode {
         encode.push_str(&format!("5303{:02}", self.currency));
         match self.amount {
             None => (),
-            Some(a) => encode.push_str(&format!("54{:02}{}", a.to_string().len(), a)),
+            Some(a) => encode.push_str(&format!("54{:02}{:.2}", a.to_string().len(), a)),
         }
         match self.convenience {
             None => (),

--- a/src/model.rs
+++ b/src/model.rs
@@ -221,7 +221,10 @@ impl BrCode {
         encode.push_str(&format!("5303{:02}", self.currency));
         match self.amount {
             None => (),
-            Some(a) => encode.push_str(&format!("54{:02}{:.2}", a.to_string().len(), a)),
+            Some(a) => {
+                let a = format!("{:.2}", a);
+                encode.push_str(&format!("54{:02}{}", a.len(), a))
+            }
         }
         match self.convenience {
             None => (),

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -33,9 +33,17 @@ fn test_brcode_to_string() {
 }
 
 #[test]
-fn test_brcode_to_string_cents_edge_case() {
+fn test_brcode_to_string_cents_edge_case1() {
     let actual = brcode::brcode_to_string(brcode_expected(Some(1.1)));
     let expected = code(Some(1.1), Some("A6C1"));
+
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn test_brcode_to_string_cents_edge_case2() {
+    let actual = brcode::brcode_to_string(brcode_expected(Some(1.0)));
+    let expected = code(Some(1.0), Some("0B9A"));
 
     assert_eq!(actual, expected);
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -35,7 +35,7 @@ fn test_brcode_to_string() {
 #[test]
 fn test_brcode_to_string_cents_edge_case1() {
     let actual = brcode::brcode_to_string(brcode_expected(Some(1.1)));
-    let expected = code(Some(1.1), Some("A6C1"));
+    let expected = code(Some(1.1), Some("779A"));
 
     assert_eq!(actual, expected);
 }
@@ -43,7 +43,7 @@ fn test_brcode_to_string_cents_edge_case1() {
 #[test]
 fn test_brcode_to_string_cents_edge_case2() {
     let actual = brcode::brcode_to_string(brcode_expected(Some(1.0)));
-    let expected = code(Some(1.0), Some("0B9A"));
+    let expected = code(Some(1.0), Some("5A3D"));
 
     assert_eq!(actual, expected);
 }
@@ -150,7 +150,7 @@ fn dynamic_code() -> String {
 
 fn code(amount: Option<f64>, crc16: Option<&str>) -> String {
     let amount = amount.unwrap_or(123.45);
-    let amount_size = amount.to_string().len();
+    let amount_size = format!("{:.2}", amount).len();
     format!("00020104141234567890123426580014BR.GOV.BCB.PIX0136123e4567-e12b-12d1-a456-42665544000027300012BR.COM.OUTRO0110012345678952040000530398654{:02}{:.2}5802BR5917NOME DO RECEBEDOR6008BRASILIA61087007490062190515RP12345678-201980390012BR.COM.OUTRO01190123.ABCD.3456.WXYZ6304{}", amount_size, amount, crc16.unwrap_or("AD38"))
 }
 


### PR DESCRIPTION
Fixes https://github.com/naomijub/brcode/issues/28

Also I made a fix for CRC16 which wasn't conforming the spec either, it should always have 4 characters.

Later we'll check if any other place in the library doesn't put zeroes before any number.